### PR TITLE
Error checking on the signup view

### DIFF
--- a/views/signup.blade.php
+++ b/views/signup.blade.php
@@ -3,17 +3,17 @@
     <!-- email field -->
     <p>{{ Form::label('email', 'Email Address') }}</p>
     <p>{{ Form::text('email', Input::old('email')) }}</p>
-    <?php if($errors) echo '<p class="error">'.$errors->first('email').'</p>'; ?>
+    <?php if($errors->has('email')) echo '<p class="error">'.$errors->first('email').'</p>'; ?>
     
     <!-- password field -->
     <p>{{ Form::label('password', 'Password') }}</p>
     <p>{{ Form::password('password') }}</p>
-    <?php if($errors) echo '<p class="error">'.$errors->first('password').'</p>'; ?>
+    <?php if($errors->has('password')) echo '<p class="error">'.$errors->first('password').'</p>'; ?>
 
     <!-- confirm password field -->
     <p>{{ Form::label('password_confirmation', 'Confirm Password') }}</p>
     <p>{{ Form::password('password_confirmation') }}</p>
-    <?php if($errors) echo '<p class="error">'.$errors->first('password_confirmation').'</p>'; ?>
+    
 
     <!-- submit button -->
     <p>{{ Form::submit('signup', array('class' => 'alert button', 'onclick' => 'return validate()')) }}</p>


### PR DESCRIPTION
I am using bootstrap css and noticed that the conditional if($errors) was always returning data, and therefore the alert-error div was always visible. I updated the conditional to be more precise. Example: if($errors->has('email')).

I also removed the last error conditional because $errors->has('passord') handle the error if the confirm password does not match.
